### PR TITLE
fix(ListCommentRequest): fix default comment status

### DIFF
--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -41,6 +41,7 @@ enum Status {
 }
 
 enum CommentStatus {
+  approve,
   approved,
   pending,
 }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -42,7 +42,6 @@ enum Status {
 
 enum CommentStatus {
   approve,
-  approved,
   pending,
 }
 

--- a/lib/src/requests/list/list_comment.dart
+++ b/lib/src/requests/list/list_comment.dart
@@ -18,7 +18,7 @@ final class ListCommentRequest extends IRequest {
     this.parent,
     this.parentExclude,
     this.post,
-    this.status = CommentStatus.approved,
+    this.status = CommentStatus.approve,
     this.type = 'comment',
     this.password,
     super.cancelToken,


### PR DESCRIPTION
The comment status to filter the comments should be 'approve' instead of 'approved' otherwise no results are returned. This has been tested with postman has we were unable to list the comments. You can look at the following reference from the wordpress documentation. The approved CommentStatus has been left in the code as it might be useful for other request type.

See [https://developer.wordpress.org/rest-api/reference/comments/#definition](https://developer.wordpress.org/rest-api/reference/comments/#definition)