### PR TITLE
fix(ListCommentRequest): add previously removed CommentStatus.approved

### DIFF
--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -42,6 +42,7 @@ enum Status {
 
 enum CommentStatus {
   approve,
+  approved,
   pending,
 }
 


### PR DESCRIPTION
To perform the ListCommentRequest we should use the CommentStatus.approve but when the results are returned, the value is 'approved'. Removing the approved value make the code break in the getCommentStatusFromValue method.